### PR TITLE
fix hassPasscode method on ios

### DIFF
--- a/example/ios/DeviceCryptoExample.xcodeproj/project.pbxproj
+++ b/example/ios/DeviceCryptoExample.xcodeproj/project.pbxproj
@@ -200,7 +200,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-DeviceCryptoExample/Pods-DeviceCryptoExample-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL/OpenSSL.framework/OpenSSL",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL-Universal/OpenSSL.framework/OpenSSL",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -245,7 +245,7 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-device-crypto (0.1.3):
+  - react-native-device-crypto (0.1.5):
     - React-Core
   - react-native-safe-area-context (3.3.2):
     - React-Core
@@ -475,7 +475,7 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-device-crypto: a8e650fbb43e12c4c375618284684d6bd636b8fa
+  react-native-device-crypto: 43a7dff8d088ad4c4ff418bb83e127f7e895d6bf
   react-native-safe-area-context: 584dc04881deb49474363f3be89e4ca0e854c057
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
@@ -494,4 +494,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 87556bb0aee33a2cfe5b159fe439523bc32ec8da
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.3

--- a/ios/DeviceCrypto.m
+++ b/ios/DeviceCrypto.m
@@ -201,7 +201,7 @@ typedef NS_ENUM(NSUInteger, AccessLevel) {
 - (BOOL) hasPassCode {
   NSError *aerr = nil;
   LAContext *context = [[LAContext alloc] init];
-  return [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&aerr];
+  return [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&aerr];
 }
 
 - (NSString*) getOrCreateKey:(nonnull NSData*) alias withOptions:(nonnull NSDictionary *)options


### PR DESCRIPTION
hasBiometry  and hasPasscode uses same policy which checks the biometry. That causes error during the key creation (unloacked device required)
The PR corrects the policy to fix the bug.